### PR TITLE
implements common build infrastructure and improve Dockerfile cache hits

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git/
+.dockerignore
+**/.gitignore
+**/c.out
+**/coverage.html
+**/Dockerfile
+**/README.md
+**/*_test.go
+**/Makefile
+awscodecommit/awscodecommit
+awscognito/awscognito
+awsdynamodb/awsdynamodb
+awsiot/awsiot
+awskinesis/awskinesis
+awss3/awss3
+awssns/awssns
+awssqs/awssqs

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,1 @@
+#!include:.dockerignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/c.out
+**/coverage.html
+**/.env
+**/.aws
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+SUBDIRS ?= awscodecommit awscognito awsdynamodb awskinesis awssqs
+TARGETS := $(shell awk '{FS = ":";} /^[a-zA-Z0-9._-]+:.*?/ { printf "%s ", $$1 }' scripts/inc.Makefile)
+
+.PHONY: $(SUBDIRS) $(TARGETS)
+
+$(TARGETS): $(SUBDIRS)
+
+$(SUBDIRS):
+	@$(MAKE) --no-print-directory -C $@ $(MAKECMDGOALS)

--- a/awscodecommit/.gitignore
+++ b/awscodecommit/.gitignore
@@ -1,5 +1,1 @@
-.aws/
-vendor/
-bin/
-creds
-.env
+awscodecommit

--- a/awscodecommit/Dockerfile
+++ b/awscodecommit/Dockerfile
@@ -1,24 +1,30 @@
-FROM golang:alpine AS builder
+FROM golang:1.14-alpine AS builder
 
-COPY awscodecommit /go/src/awscodecommit
+ENV GO111MODULE on
+ENV CGO_ENABLED 0
+ENV GOOS linux
+ENV GOARCH amd64
+
 WORKDIR /go/src/awscodecommit
 
 RUN apk update && apk add --no-cache openssh-client ca-certificates
-RUN GO111MODULE=on go mod download && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/awscodecommit
+
+COPY awscodecommit/go.mod awscodecommit/go.sum /go/src/awscodecommit/
+RUN go mod download
+
+COPY awscodecommit/ /go/src/awscodecommit/
+RUN go install -installsuffix cgo ./...
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-LABEL name="Triggermesh AWS CodeCommit Event Source" \
-      vendor="Triggermesh" \
-      version="v0.1.0" \
-      release="1" \
-      summary="The Triggermesh CodeCommit Source" \
-      description="This is the Triggermesh Knative Event Source for AWS CodeCommit"
+LABEL name "Triggermesh AWS CodeCommit Event Source"
+LABEL vendor "Triggermesh"
+LABEL version "v0.1.0"
+LABEL release "1"
+LABEL summary "The Triggermesh CodeCommit Source"
+LABEL description "This is the Triggermesh Knative Event Source for AWS CodeCommit"
 
-RUN microdnf update
-COPY ./licenses/* /licenses/
-
+COPY licenses/ /licenses/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/awscodecommit /go/bin/awscodecommit
 

--- a/awscodecommit/Makefile
+++ b/awscodecommit/Makefile
@@ -1,15 +1,4 @@
-TARGET=awscodecommit
+PACKAGE = awscodecommit
+PACKAGE_DESC = Triggermesh AWS CodeCommit Event Source
 
-all: clean fmt vet
-
-clean:
-	rm -rf $(TARGET)
-
-fmt:
-	go fmt ./...
-
-lint:
-	golint ./...
-
-vet:
-	go vet ./...
+include ../scripts/inc.Makefile

--- a/awscognito/.gitignore
+++ b/awscognito/.gitignore
@@ -1,3 +1,1 @@
 awscognito
-.env
-vendor

--- a/awscognito/Dockerfile
+++ b/awscognito/Dockerfile
@@ -1,24 +1,30 @@
-FROM golang:alpine AS builder
+FROM golang:1.14-alpine AS builder
 
-COPY awscognito /go/src/awscognito
+ENV GO111MODULE on
+ENV CGO_ENABLED 0
+ENV GOOS linux
+ENV GOARCH amd64
+
 WORKDIR /go/src/awscognito
 
 RUN apk update && apk add --no-cache openssh-client ca-certificates
-RUN GO111MODULE=on go mod download && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/awscognito
+
+COPY awscognito/go.mod awscognito/go.sum /go/src/awscognito/
+RUN go mod download
+
+COPY awscognito/ /go/src/awscognito/
+RUN go install -installsuffix cgo ./...
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-LABEL name="Triggermesh AWS Cognito Event Source" \
-      vendor="Triggermesh" \
-      version="v0.1.0" \
-      release="1" \
-      summary="The Triggermesh Cognito Source" \
-      description="This is the Triggermesh Knative Event Source for AWS Cognito"
+LABEL name "Triggermesh AWS Cognito Event Source"
+LABEL vendor "Triggermesh"
+LABEL version "v0.1.0"
+LABEL release "1"
+LABEL summary "The Triggermesh Cognito Source"
+LABEL description "This is the Triggermesh Knative Event Source for AWS Cognito"
 
-RUN microdnf update
-COPY ./licenses/* /licenses/
-
+COPY licenses/ /licenses/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/awscognito /go/bin/awscognito
 

--- a/awscognito/Makefile
+++ b/awscognito/Makefile
@@ -1,15 +1,4 @@
-TARGET=awscognito
+PACKAGE = awscognito
+PACKAGE_DESC = Triggermesh AWS Cognito Event Source
 
-all: clean fmt vet
-
-clean:
-	rm -rf $(TARGET)
-
-fmt:
-	go fmt ./...
-
-lint:
-	golint ./...
-
-vet:
-	go vet ./...
+include ../scripts/inc.Makefile

--- a/awsdynamodb/.gitignore
+++ b/awsdynamodb/.gitignore
@@ -1,3 +1,1 @@
-.env
-vendor
 awsdynamodb

--- a/awsdynamodb/Dockerfile
+++ b/awsdynamodb/Dockerfile
@@ -1,24 +1,30 @@
-FROM golang:alpine AS builder
+FROM golang:1.14-alpine AS builder
 
-COPY awsdynamodb /go/src/awsdynamodb
+ENV GO111MODULE on
+ENV CGO_ENABLED 0
+ENV GOOS linux
+ENV GOARCH amd64
+
 WORKDIR /go/src/awsdynamodb
 
 RUN apk update && apk add --no-cache openssh-client ca-certificates
-RUN GO111MODULE=on go mod download && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/awsdynamodb
+
+COPY awsdynamodb/go.mod awsdynamodb/go.sum /go/src/awsdynamodb/
+RUN go mod download
+
+COPY awsdynamodb/ /go/src/awsdynamodb/
+RUN go install -installsuffix cgo ./...
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-LABEL name="Triggermesh AWS DynamoDB Event Source" \
-      vendor="Triggermesh" \
-      version="v0.1.0" \
-      release="1" \
-      summary="The Triggermesh DynamoDB Source" \
-      description="This is the Triggermesh Knative Event Source for AWS DynamoDB"
+LABEL name "Triggermesh AWS DynamoDB Event Source"
+LABEL vendor "Triggermesh"
+LABEL version "v0.1.0"
+LABEL release "1"
+LABEL summary "The Triggermesh DynamoDB Source"
+LABEL description "This is the Triggermesh Knative Event Source for AWS DynamoDB"
 
-RUN microdnf update
-COPY ./licenses/* /licenses/
-
+COPY licenses/ /licenses/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/awsdynamodb /go/bin/awsdynamodb
 

--- a/awsdynamodb/Makefile
+++ b/awsdynamodb/Makefile
@@ -1,15 +1,4 @@
-TARGET=awsdynamodb
+PACKAGE = awsdynamodb
+PACKAGE_DESC = Triggermesh AWS DynamoDB Event Source
 
-all: clean fmt vet
-
-clean:
-	rm -rf $(TARGET)
-
-fmt:
-	go fmt ./...
-
-lint:
-	golint ./...
-
-vet:
-	go vet ./...
+include ../scripts/inc.Makefile

--- a/awskinesis/.gitignore
+++ b/awskinesis/.gitignore
@@ -1,2 +1,1 @@
-.env
-vendor
+awskinesis

--- a/awskinesis/Dockerfile
+++ b/awskinesis/Dockerfile
@@ -1,24 +1,30 @@
-FROM golang:alpine AS builder
+FROM golang:1.14-alpine AS builder
 
-COPY awskinesis /go/src/awskinesis
+ENV GO111MODULE on
+ENV CGO_ENABLED 0
+ENV GOOS linux
+ENV GOARCH amd64
+
 WORKDIR /go/src/awskinesis
 
 RUN apk update && apk add --no-cache openssh-client ca-certificates
-RUN GO111MODULE=on go mod download && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/awskinesis
+
+COPY awskinesis/go.mod awskinesis/go.sum /go/src/awskinesis/
+RUN go mod download
+
+COPY awskinesis/ /go/src/awskinesis/
+RUN go install -installsuffix cgo ./...
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-LABEL name="Triggermesh AWS Kinesis Event Source" \
-      vendor="Triggermesh" \
-      version="v0.1.0" \
-      release="1" \
-      summary="The Triggermesh Kinesis Source" \
-      description="This is the Triggermesh Knative Event Source for AWS Kinesis"
+LABEL name "Triggermesh AWS Kinesis Event Source"
+LABEL vendor "Triggermesh"
+LABEL version "v0.1.0"
+LABEL release "1"
+LABEL summary "The Triggermesh Kinesis Source"
+LABEL description "This is the Triggermesh Knative Event Source for AWS Kinesis"
 
-RUN microdnf update
-COPY ./licenses/* /licenses/
-
+COPY licenses/ /licenses/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/awskinesis /go/bin/awskinesis
 

--- a/awskinesis/Makefile
+++ b/awskinesis/Makefile
@@ -1,15 +1,4 @@
-TARGET=awskinesis
+PACKAGE = awskinesis
+PACKAGE_DESC = Triggermesh Kinesis Cognito Event Source
 
-all: clean fmt vet
-
-clean:
-	rm -rf $(TARGET)
-
-fmt:
-	go fmt ./...
-
-lint:
-	golint ./...
-
-vet:
-	go vet ./...
+include ../scripts/inc.Makefile

--- a/awssns/.gitignore
+++ b/awssns/.gitignore
@@ -1,3 +1,1 @@
-vendor
-.env
 awssns

--- a/awssns/Dockerfile
+++ b/awssns/Dockerfile
@@ -1,13 +1,23 @@
-FROM golang:alpine AS builder
+FROM golang:1.14-alpine AS builder
 
-COPY awssns /go/src/awssns
+ENV GO111MODULE on
+ENV CGO_ENABLED 0
+ENV GOOS linux
+ENV GOARCH amd64
+
 WORKDIR /go/src/awssns
 
 RUN apk update && apk add --no-cache openssh-client ca-certificates
-RUN GO111MODULE=on go mod download && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/awssns
+
+COPY awssns/go.mod awssns/go.sum /go/src/awssns/
+RUN go mod download
+
+COPY awssns/ /go/src/awssns/
+RUN go install -installsuffix cgo ./...
 
 FROM scratch
+
+COPY licenses/ /licenses/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/awssns /go/bin/awssns
 

--- a/awssns/Makefile
+++ b/awssns/Makefile
@@ -1,15 +1,4 @@
-TARGET=awssns
+PACKAGE = awssns
+PACKAGE_DESC = Triggermesh AWS SNS Event Source
 
-all: clean fmt vet
-
-clean:
-	rm -rf $(TARGET)
-
-fmt:
-	go fmt ./...
-
-lint:
-	golint ./...
-
-vet:
-	go vet ./...
+include ../scripts/inc.Makefile

--- a/awssqs/.gitignore
+++ b/awssqs/.gitignore
@@ -1,5 +1,1 @@
-.aws/
-vendor/
-bin/
-creds
-.env
+awssqs

--- a/awssqs/Dockerfile
+++ b/awssqs/Dockerfile
@@ -1,25 +1,31 @@
-FROM golang:alpine AS builder
+FROM golang:1.14-alpine AS builder
 
-COPY awssqs /go/src/sqs
-WORKDIR /go/src/sqs
+ENV GO111MODULE on
+ENV CGO_ENABLED 0
+ENV GOOS linux
+ENV GOARCH amd64
+
+WORKDIR /go/src/awssqs
 
 RUN apk update && apk add --no-cache openssh-client ca-certificates
-RUN GO111MODULE=on go mod download && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/sqs
+
+COPY awssqs/go.mod awssqs/go.sum /go/src/awssqs/
+RUN go mod download
+
+COPY awssqs/ /go/src/awssqs/
+RUN go install -installsuffix cgo ./...
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-LABEL name="Triggermesh AWS SQS Event Source" \
-      vendor="Triggermesh" \
-      version="v0.1.0" \
-      release="1" \
-      summary="The Triggermesh SQS Source" \
-      description="This is the Triggermesh Knative Event Source for AWS SQS"
+LABEL name "Triggermesh AWS SQS Event Source"
+LABEL vendor "Triggermesh"
+LABEL version "v0.1.0"
+LABEL release "1"
+LABEL summary "The Triggermesh SQS Source"
+LABEL description "This is the Triggermesh Knative Event Source for AWS SQS"
 
-RUN microdnf update
-COPY ./licenses/* /licenses/
-
+COPY licenses/ /licenses/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /go/bin/sqs /go/bin/sqs
+COPY --from=builder /go/bin/awssqs /go/bin/awssqs
 
-ENTRYPOINT ["/go/bin/sqs"]
+ENTRYPOINT ["/go/bin/awssqs"]

--- a/awssqs/Makefile
+++ b/awssqs/Makefile
@@ -1,15 +1,4 @@
-TARGET=awssqs
+PACKAGE = awssqs
+PACKAGE_DESC = Triggermesh AWS SQS Event Source
 
-all: clean fmt vet
-
-clean:
-	rm -rf $(TARGET)
-
-fmt:
-	go fmt ./...
-
-lint:
-	golint ./...
-
-vet:
-	go vet ./...
+include ../scripts/inc.Makefile

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,50 +1,33 @@
-#################
-## AWS Sources ##
-#################
 steps:
-## Build DynamoDB source
-- name: 'gcr.io/kaniko-project/executor:latest'
-  args:
-  - --dockerfile=awsdynamodb/Dockerfile
-  - --destination=gcr.io/$PROJECT_ID/awsdynamodb
-  - --cache=true
-  waitFor: ['-']
-## Build SQS source
-- name: 'gcr.io/kaniko-project/executor:latest'
-  args:
-  - --dockerfile=awssqs/Dockerfile
-  - --destination=gcr.io/$PROJECT_ID/awssqs
-  - --cache=true
-  waitFor: ['-']
-## Build CodeCommit source
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awscodecommit/Dockerfile
-  - --destination=gcr.io/$PROJECT_ID/awscodecommit
+  - --destination=gcr.io/$PROJECT_ID/awscodecommit:latest
   - --cache=true
   waitFor: ['-']
-## Build Cognito source
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awscognito/Dockerfile
-  - --destination=gcr.io/$PROJECT_ID/awscognito
+  - --destination=gcr.io/$PROJECT_ID/awscognito:latest
   - --cache=true
   waitFor: ['-']
-## Build Kinesis source
+- name: 'gcr.io/kaniko-project/executor:latest'
+  args:
+  - --dockerfile=awsdynamodb/Dockerfile
+  - --destination=gcr.io/$PROJECT_ID/awsdynamodb:latest
+  - --cache=true
+  waitFor: ['-']
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awskinesis/Dockerfile
-  - --destination=gcr.io/$PROJECT_ID/awskinesis
+  - --destination=gcr.io/$PROJECT_ID/awskinesis:latest
   - --cache=true
   waitFor: ['-']
-# To speed up builds
+- name: 'gcr.io/kaniko-project/executor:latest'
+  args:
+  - --dockerfile=awssqs/Dockerfile
+  - --destination=gcr.io/$PROJECT_ID/awssqs:latest
+  - --cache=true
+  waitFor: ['-']
 options:
   machineType: 'N1_HIGHCPU_8'
-
-## Build Kinesis source
-#- name: 'gcr.io/cloud-builders/docker'
-#  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/awss3:latest', '-f' ,'./awss3/Dockerfile', '.' ]
-
-## Build SNS source
-#- name: 'gcr.io/cloud-builders/docker'
-#  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/awssns:latest', '-f' ,'./awssns/Dockerfile', '.' ]

--- a/hack/kinesisproducer/Makefile
+++ b/hack/kinesisproducer/Makefile
@@ -1,15 +1,2 @@
-TARGET=awskinesisproducer
-
-all: clean fmt vet
-
-clean:
-	rm -rf $(TARGET)
-
-fmt:
-	go fmt ./...
-
-lint:
-	golint ./...
-
-vet:
-	go vet ./...
+PACKAGE = awskinesisproducer
+include ../../scripts/inc.Makefile

--- a/scripts/inc.Makefile
+++ b/scripts/inc.Makefile
@@ -1,0 +1,53 @@
+RM         ?= rm
+CP         ?= cp
+MV         ?= mv
+
+GO         ?= go
+GOFMT      ?= gofmt
+GOLINT     ?= golint
+GOTEST     ?= go test
+GOTOOL     ?= go tool
+
+DOCKER     ?= docker
+
+LDFLAGS     =
+
+all: build
+
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*?## "; printf "\n$(PACKAGE_DESC)\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9._-]+:.*?## / {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+mod-download: ## Download modules using 'go mod download'
+	$(GO) mod download
+
+build: ## Build the binary using 'go build'
+	$(GO) build -ldflags "$(LDFLAGS)" -installsuffix cgo -o $(PACKAGE)
+
+install: ## Install the binary using the 'go install'
+	$(GO) install -ldflags "$(LDFLAGS)" -installsuffix cgo
+
+test: ## Run unit tests
+	$(GOTEST) ./...
+
+coverage: ## Generate code coverage
+	@$(GOTEST) -coverprofile=c.out ./...
+	@$(GOTOOL) cover -html=c.out -o coverage.html
+
+lint: ## Link source files using 'golint'
+	$(GOLINT) ./...
+
+vet: ## Vet source files using 'go vet'
+	$(GO) vet ./...
+
+fmt: ## Format source files using 'gofmt'
+	$(GOFMT) -s -w $(shell $(GO) list -f '{{$$d := .Dir}}{{range .GoFiles}}{{$$d}}/{{.}}{{end}} {{$$d := .Dir}}{{range .TestGoFiles}}{{$$d}}/{{.}}{{end}}' ./...)
+
+fmt-test: ## Check source formatting using 'gofmt'
+	@test -z $(shell $(GOFMT) -l $(shell $(GO) list -f '{{$$d := .Dir}}{{range .GoFiles}}{{$$d}}/{{.}}{{end}} {{$$d := .Dir}}{{range .TestGoFiles}}{{$$d}}/{{.}}{{end}}' ./...))
+
+image: ## Build docker image using 'docker build'
+	$(DOCKER) build -t gcr.io/triggermesh/$(PACKAGE) -f Dockerfile ../
+
+clean: ## Clean build artifacts
+	@$(RM) -rf $(PACKAGE)
+	@$(RM) -rf c.out coverage.html


### PR DESCRIPTION
In this change we have restructured the Dockerfiles to improve cache hits and also implemented a common build infratructure.
For example you can build all the sources with `make build` or build all images with `make image`. Similarly to test all sources you can do `make test`.

Alternatively if you only want to test the `awskinesis` source, you can do `make -C awskinesis test`.

Execute `make -C awskinesis help` to get the list of all available targets

Closes #45 