### PR TITLE
fixes broken tests

### DIFF
--- a/awscognito/main_test.go
+++ b/awscognito/main_test.go
@@ -136,6 +136,8 @@ func TestSendCognitoEvent(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
+	identityPoolID = "fooPool"
+
 	httpmock.RegisterResponder("POST", "https://foo.com", httpmock.NewStringResponder(200, ``))
 	httpmock.RegisterResponder("POST", "https://bar.com", httpmock.NewStringResponder(500, ``))
 

--- a/awsdynamodb/main_test.go
+++ b/awsdynamodb/main_test.go
@@ -248,6 +248,8 @@ func TestSendCloudevent(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
+	tableName = "fooTable"
+
 	httpmock.RegisterResponder("POST", "https://foo.com", httpmock.NewStringResponder(200, ``))
 	httpmock.RegisterResponder("POST", "https://bar.com", httpmock.NewStringResponder(500, ``))
 

--- a/awskinesis/main_test.go
+++ b/awskinesis/main_test.go
@@ -124,6 +124,8 @@ func TestSendCloudevent(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
+	streamName = "fooStream"
+
 	httpmock.RegisterResponder("POST", "https://foo.com", httpmock.NewStringResponder(200, ``))
 
 	record := kinesis.Record{


### PR DESCRIPTION
The components require certain environment variable to exist in the environment. Certain tests fail because specific environment variables do no exist.

f.e.

```
--- FAIL: TestSendCloudevent (0.00s)
    main_test.go:148: 
        	Error Trace:	main_test.go:148
        	Error:      	Received unexpected error:
        	            	subject: if present, MUST be a non-empty string
        	Test:       	TestSendCloudevent
```