### PR TITLE
cloudbuild: increate build timeout and restore use of `N1_HIGHCPU_8` machine

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,40 +4,50 @@ steps:
   args:
   - --dockerfile=awscodecommit/Dockerfile
   - --destination=gcr.io/$PROJECT_ID/awscodecommit:latest
-  - --cache=true
+  - --cache=$_USE_BUILD_CACHE
+  - $_KANIKO_EXTRA_ARGS
   waitFor: ['-']
 
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awscognito/Dockerfile
   - --destination=gcr.io/$PROJECT_ID/awscognito:latest
-  - --cache=true
+  - --cache=$_USE_BUILD_CACHE
+  - $_KANIKO_EXTRA_ARGS
   waitFor: ['-']
 
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awsdynamodb/Dockerfile
   - --destination=gcr.io/$PROJECT_ID/awsdynamodb:latest
-  - --cache=true
+  - --cache=$_USE_BUILD_CACHE
+  - $_KANIKO_EXTRA_ARGS
   waitFor: ['-']
 
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awskinesis/Dockerfile
   - --destination=gcr.io/$PROJECT_ID/awskinesis:latest
-  - --cache=true
+  - --cache=$_USE_BUILD_CACHE
+  - $_KANIKO_EXTRA_ARGS
   waitFor: ['-']
 
 - name: 'gcr.io/kaniko-project/executor:latest'
   args:
   - --dockerfile=awssqs/Dockerfile
   - --destination=gcr.io/$PROJECT_ID/awssqs:latest
-  - --cache=true
+  - --cache=$_USE_BUILD_CACHE
+  - $_KANIKO_EXTRA_ARGS
   waitFor: ['-']
 
 timeout: 600s
 
+substitutions:
+  _USE_BUILD_CACHE: "false"
+  _KANIKO_EXTRA_ARGS: ""
+
 options:
+  substitution_option: 'ALLOW_LOOSE'
   machineType: 'N1_HIGHCPU_8'
 
 tags:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,5 +35,7 @@ steps:
   - --cache=true
   waitFor: ['-']
 
+timeout: 600s
+
 tags:
   - knative-lambda-sources

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,5 +37,8 @@ steps:
 
 timeout: 600s
 
+options:
+  machineType: 'N1_HIGHCPU_8'
+
 tags:
   - knative-lambda-sources


### PR DESCRIPTION
the builds timeout if there are no cache hits for all. to fix this i've restore the use of `N1_HIGHCPU_8` machine type for the builds and additionally increased the builds timeout to `600s` as  a additional measure.